### PR TITLE
fixed duplicate comments displaying

### DIFF
--- a/BeerTier/Repositories/BeerRepository.cs
+++ b/BeerTier/Repositories/BeerRepository.cs
@@ -175,6 +175,7 @@ namespace BeerTier.Repositories
                                 beer.Comments.Add(
                                     new Comment()
                                     {
+                                        Id = DbUtils.GetInt(reader, "CommentId"),
                                         Content = DbUtils.GetString(reader, "CommentContent"),
                                         CreateDateTime = DbUtils.GetDateTime(
                                             reader,


### PR DESCRIPTION
* `Comment.Id` was not being assigned in the GetById repository method
* closes #35 